### PR TITLE
worked on search controller show route to reduce returned members to only 3 replace merge method

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -1,23 +1,27 @@
 class SearchController < ApplicationController
 
   def show
+    search_term = params[:searchTerm].downcase
+    priority = "#{search_term}%"
+    fuzzy = "%#{search_term}%"
 
-    fuzzy = "%#{params[:searchTerm].downcase}%"
-    priority = "#{params[:searchTerm].downcase}%"
+    result_limit = 3
+    @member_results = search_members_by_name(priority, result_limit)
+    found_names = get_found_members_names(@member_results)
 
-    @member_results_by_name = Member.limit(3).where('lower(name) LIKE ?', priority).order(:name)
-
-    @member_results = Member.limit(3).where(
-      'lower(name) LIKE ? OR lower(info) LIKE ? OR lower(snippet) LIKE ? OR lower(location) LIKE ?',
+    result_limit -= @member_results_by_name.length
+    @member_results = Member.limit(result_limit).where(
+      "lower(name) NOT IN (#{found_names}) AND (lower(name) LIKE ? OR lower(info) LIKE ? OR lower(snippet) LIKE ? OR lower(location) LIKE ?)",
       fuzzy,
       fuzzy,
       fuzzy,
       fuzzy
     ).order(:name)
-    sorted_by_name = @member_results_by_name.merge(@member_results)
+
+    sorted_by_name = @member_results_by_name + @member_results
     sorted_by_name = sorted_by_name.as_json({
-        include: [:donations, :comments, :sponsors]
-      })
+      include: [:donations, :comments, :sponsors]
+    })
 
     @charity_results = Charity.limit(3).where(
       'lower(name) LIKE ? OR lower(description) LIKE ?',
@@ -28,4 +32,16 @@ class SearchController < ApplicationController
     render json: ({ members: sorted_by_name, charities: @charity_results })
   end
 
+end
+
+def search_members_by_name(search_term, limit)
+  return @member_results_by_name = Member.limit(limit).where('lower(name) LIKE ?', search_term).order(:name)
+end
+
+def get_found_members_names(members)
+  found_names = []
+  for member in @member_results_by_name
+    found_names.push("'#{member.name.downcase}'")
+  end
+  return found_names.length > 0 ? found_names.join(", ") : "'0'"
 end


### PR DESCRIPTION
Was playing around and notice the changes me and Reece made to the searchController made more than 3 members be returned (which was the limit when there was only one query). Thought I would quickly fix that then noticed the merge method wasn't doing what we though and kinda ignored the second query. This should fix all that. 